### PR TITLE
Fix types for DEX rpc

### DIFF
--- a/packages/api/src/libs/getApiOptions.ts
+++ b/packages/api/src/libs/getApiOptions.ts
@@ -47,7 +47,7 @@ export function getRpcOptions(): ApiOptions["rpc"] {
 				params: [
 					{
 						name: "amountIn",
-						type: "Balance",
+						type: "u128",
 					},
 					{
 						name: "path",
@@ -61,7 +61,7 @@ export function getRpcOptions(): ApiOptions["rpc"] {
 				params: [
 					{
 						name: "amountOut",
-						type: "Balance",
+						type: "u128",
 					},
 					{
 						name: "path",


### PR DESCRIPTION
## Summary

Update the getAmountsIn and getAmountsOut input type from Balance to u128

<img width="1702" alt="Screenshot 2023-08-29 at 6 14 10 PM" src="https://github.com/futureversecom/trn-js-api/assets/29415595/0fc34e8b-9889-4118-a7d1-9f102bc9481d">


## Checklist

- [x] Add description
- [ ] Tag related issue(s)
- [ ] Add appropriate tests
