### PR TITLE
chore: resolve new `@polkadot/...` packages added in `extrinsic`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   },
   "resolutions": {
     "@polkadot/api": "10.9.1",
+    "@polkadot/api-base": "10.9.1",
     "@polkadot/types": "10.9.1",
     "@polkadot/types-codec": "10.9.1",
     "@polkadot/util": "12.6.2",
+    "@polkadot/util-crypto": "12.6.2",
     "@polkadot/keyring": "12.6.2"
   },
   "packageManager": "pnpm@8.6.12"

--- a/packages/extrinsic/package.json
+++ b/packages/extrinsic/package.json
@@ -6,9 +6,9 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@polkadot/api": "^10.9.1",
-    "@polkadot/api-base": "^10.9.1",
     "@polkadot/keyring": "^12.6.2",
     "@polkadot/types": "^10.9.1",
+    "@polkadot/types-codec": "^10.9.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "@therootnetwork/api": "^1.0.8",
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@polkadot/api": "^10.9.1",
-    "@polkadot/api-base": "^10.9.1",
     "@polkadot/types": "^10.9.1",
     "@polkadot/types-codec": "^10.9.1",
     "@polkadot/util": "^12.6.2",

--- a/packages/extrinsic/src/utils.ts
+++ b/packages/extrinsic/src/utils.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { IKeyringPair, Registry } from "@polkadot/types/types";
 
-import { SignerOptions } from "@polkadot/api-base/types/submittable";
+import { SignerOptions } from "@polkadot/api/types";
 import { EventRecord, RuntimeDispatchInfo } from "@polkadot/types/interfaces";
 import { IExtrinsicEra, SignatureOptions } from "@polkadot/types/types";
 import { ethereumEncode } from "@polkadot/util-crypto/ethereum";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,11 @@ settings:
 
 overrides:
   '@polkadot/api': 10.9.1
+  '@polkadot/api-base': 10.9.1
   '@polkadot/types': 10.9.1
   '@polkadot/types-codec': 10.9.1
   '@polkadot/util': 12.6.2
+  '@polkadot/util-crypto': 12.6.2
   '@polkadot/keyring': 12.6.2
 
 importers:
@@ -80,7 +82,7 @@ importers:
         version: 10.9.1
     devDependencies:
       '@polkadot/api-base':
-        specifier: ^10.9.1
+        specifier: 10.9.1
         version: 10.9.1
       '@polkadot/rpc-core':
         specifier: ^10.9.1
@@ -144,7 +146,7 @@ importers:
         specifier: 10.9.1
         version: 10.9.1
       '@polkadot/api-base':
-        specifier: ^10.9.1
+        specifier: 10.9.1
         version: 10.9.1
       '@polkadot/types':
         specifier: 10.9.1
@@ -156,7 +158,7 @@ importers:
         specifier: 12.6.2
         version: 12.6.2
       '@polkadot/util-crypto':
-        specifier: ^12.6.2
+        specifier: 12.6.2
         version: 12.6.2(@polkadot/util@12.6.2)
       dotenv:
         specifier: ^16.3.2
@@ -1310,7 +1312,6 @@ packages:
     resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
     dependencies:
       '@noble/hashes': 1.4.0
-    dev: true
 
   /@noble/hashes@1.1.2:
     resolution: {integrity: sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==}
@@ -1597,7 +1598,7 @@ packages:
     peerDependencies:
       '@polkadot/util': 12.6.2
     dependencies:
-      '@noble/curves': 1.3.0
+      '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@polkadot/networks': 12.6.2
       '@polkadot/util': 12.6.2
@@ -1605,7 +1606,7 @@ packages:
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
       '@polkadot/x-bigint': 12.6.2
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2)
-      '@scure/base': 1.1.5
+      '@scure/base': 1.1.6
       tslib: 2.6.2
 
   /@polkadot/util@12.6.2:
@@ -1756,7 +1757,6 @@ packages:
 
   /@scure/base@1.1.6:
     resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
-    dev: true
 
   /@scure/bip32@1.4.0:
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,9 +145,6 @@ importers:
       '@polkadot/api':
         specifier: 10.9.1
         version: 10.9.1
-      '@polkadot/api-base':
-        specifier: 10.9.1
-        version: 10.9.1
       '@polkadot/types':
         specifier: 10.9.1
         version: 10.9.1


### PR DESCRIPTION
## Summary

 - Resolve `api-base` and `util-crypto` packages

## Checklist

- [x] Add description
