### PR TITLE
spike/extrinsic: Estimate XRPL signed extrinsic

### DIFF
--- a/packages/extrinsic/src/libs/createDispatcher.ts
+++ b/packages/extrinsic/src/libs/createDispatcher.ts
@@ -23,7 +23,8 @@ export function createDispatcher(
 	api: ApiPromise,
 	senderAddress: string,
 	partialWrappers: PartialWrapper[],
-	partialSigner: PartialSigner
+	partialSigner: PartialSigner,
+	isXrplDispatcher?: boolean
 ): SignDispatcher;
 
 /**
@@ -39,13 +40,14 @@ export function createDispatcher(
 	api: ApiPromise,
 	senderAddress: string,
 	partialWrappers: PartialWrapper[] = [],
-	partialSigner?: PartialSigner
+	partialSigner?: PartialSigner,
+	isXrplDispatcher = false
 ): SignDispatcher | UnsignDispatcher {
 	const wrappers = partialWrappers.map((wrapper) => wrapper(api, senderAddress)());
 
 	const estimate = async (extrinsic: Extrinsic, assetId = XRP_ASSET_ID) => {
 		const wrapResult = await wrapFn(extrinsic, wrappers);
-		return await estimateFn(api, senderAddress, wrapResult, assetId);
+		return await estimateFn(api, senderAddress, wrapResult, assetId, isXrplDispatcher);
 	};
 
 	const send = async (extrinsic: Extrinsic, onProgress?: ProgressCallback) => {

--- a/packages/extrinsic/src/libs/estimate.ts
+++ b/packages/extrinsic/src/libs/estimate.ts
@@ -6,6 +6,13 @@ import { ok } from "neverthrow";
 
 const errPrefix = errWithPrefix("Estimate");
 
+const mockXrplPayload = {
+	message:
+		"0x5916969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C25807321EDFB2A3A850B43E24D2700532EF1F9CCB2475DFF4F62B634B0C58845F23C26396581145116224CEF7355137BEBBA8E277A9BE18E0596E7F9EA7C0965787472696E7369637D8E383339353966376634323632373632663735393963326661343862343138623765313032663932633831666162396536656632326162333739616264623732663A333A31323639343937353A303A33623034653934373565373336353763616665393561653138656335363963336436383738353539643661633939333437316364623562646635396339636432E1F1",
+	signature:
+		"0x3BC417D12C9595ABB4551CE518ACDD70AE3B9D9B55CF5110BD5009B4A098AE62CC8C66CD422A0DF67A2B08894C15E423CE6F1EFFCAC540964F84A57E31399102",
+};
+
 /**
  * Returns fee estimation for a given extrinsic
  *
@@ -19,7 +26,8 @@ export async function estimate(
 	api: ApiPromise,
 	senderAddress: string,
 	extrinsicOrResult: Extrinsic | Result<Extrinsic, Error>,
-	assetId = XRP_ASSET_ID
+	assetId = XRP_ASSET_ID,
+	isXrplSigner = false
 ) {
 	try {
 		let extrinsic = extrinsicOrResult;
@@ -27,7 +35,14 @@ export async function estimate(
 			if (!extrinsic.ok) return extrinsic;
 			extrinsic = extrinsic.value;
 		}
-		const fetchResult = await fetchPaymentInfo(api, senderAddress, extrinsic, assetId);
+		const fetchResult = await fetchPaymentInfo(
+			api,
+			senderAddress,
+			isXrplSigner
+				? api.tx.xrpl.transact(mockXrplPayload.message, mockXrplPayload.signature, extrinsic)
+				: extrinsic,
+			assetId
+		);
 
 		if (fetchResult.isErr())
 			return safeReturn(errPrefix(fetchResult.error.message, fetchResult.error.cause));

--- a/packages/extrinsic/tests/e2e/createDispatcher.test.ts
+++ b/packages/extrinsic/tests/e2e/createDispatcher.test.ts
@@ -208,11 +208,12 @@ describe("createDispatcher", () => {
 			true
 		);
 
-		const remarkResult = await signAndSend(api.tx.system.remarkWithEvent("hello"));
+		const extrinsic = api.tx.system.remarkWithEvent("hello");
 
-		const estimatedFee = await estimate(api.tx.system.remarkWithEvent("hello"), undefined);
+		const estimatedFee = await estimate(extrinsic);
 		expect(estimatedFee.ok).toBe(true);
 
+		const remarkResult = await signAndSend(extrinsic);
 		expect(remarkResult.ok).toBe(true);
 		const { id, result } = remarkResult.value as ExtrinsicResult;
 

--- a/packages/extrinsic/tests/e2e/createDispatcher.test.ts
+++ b/packages/extrinsic/tests/e2e/createDispatcher.test.ts
@@ -185,4 +185,51 @@ describe("createDispatcher", () => {
 
 		expect(remarkEvent).toBeDefined();
 	}, 10000);
+
+	test("estimates XRPL extrinsic correctly", async () => {
+		const sender = new Wallet(process.env.CALLER_PRIVATE_KEY as string);
+		const publicKey = sender.signingKey.compressedPublicKey;
+
+		const { signAndSend, estimate } = createDispatcher(
+			api,
+			sender.address,
+			[],
+			xrplWalletSigner((Memos) => {
+				const payload = {
+					Memos,
+					AccountTxnID: "16969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C2580",
+					SigningPubKey: publicKey.slice(2),
+					Account: deriveAddress(publicKey.slice(2)),
+				};
+				const signature = sign(encodeForSigning(payload), sender.privateKey.slice(2));
+
+				return new Promise((resolve) => resolve({ signature, message: encode(payload) }));
+			}),
+			true
+		);
+
+		const remarkResult = await signAndSend(api.tx.system.remarkWithEvent("hello"));
+
+		const estimatedFee = await estimate(api.tx.system.remarkWithEvent("hello"), undefined);
+		expect(estimatedFee.ok).toBe(true);
+
+		expect(remarkResult.ok).toBe(true);
+		const { id, result } = remarkResult.value as ExtrinsicResult;
+
+		expect(id).toBeDefined();
+		const [remarkEvent, feeEvent] = filterExtrinsicEvents(result.events, [
+			"system.Remarked",
+			"assetsExt.InternalWithdraw",
+		]);
+
+		expect(remarkEvent).toBeDefined();
+		expect(feeEvent).toBeDefined();
+
+		if (!feeEvent) {
+			throw new Error("Fee event not found");
+		}
+		const feeEventData = (feeEvent.toJSON().event as { data: [number, string, number] }).data;
+
+		expect(estimatedFee.value).toBeGreaterThanOrEqual(feeEventData[2]);
+	}, 10000);
 });


### PR DESCRIPTION
## Summary
 - Wrap estimated extrinsic with `api.tx.xrpl.transact` with mock data

## Checklist

- [x] Add description
- [ ] Tag related issue(s)
- [x] Add appropriate tests
