### PR TITLE
Add `fpAddressHint` parameter

### DIFF
--- a/packages/extrinsic/src/libs/wrapWithFuturepass.ts
+++ b/packages/extrinsic/src/libs/wrapWithFuturepass.ts
@@ -2,6 +2,7 @@ import { ApiPromise } from "@polkadot/api";
 import { fromPromise, ok, err } from "neverthrow";
 import { errWithPrefix } from "../utils";
 import { Extrinsic } from "../types";
+import { Option, U8aFixed } from "@polkadot/types";
 
 const errPrefix = errWithPrefix("FuturepassWrapper");
 
@@ -41,7 +42,7 @@ async function fetchFuturepassAddress(api: ApiPromise, senderAddress: string) {
 	);
 
 	if (result.isErr()) return err(result.error);
-	const fpAddress = result.value;
+	const fpAddress = result.value as Option<U8aFixed>;
 
 	if (fpAddress.isEmpty)
 		return err(new Error(`Unable to extract Futurepass address for "${senderAddress}"`));

--- a/packages/extrinsic/src/libs/wrapWithFuturepass.ts
+++ b/packages/extrinsic/src/libs/wrapWithFuturepass.ts
@@ -11,17 +11,13 @@ const errPrefix = errWithPrefix("FuturepassWrapper");
  *
  * @param api - An instance of `ApiPromise` from `@polkadot/api`
  * @param senderAddress - The sender's address
- * @param preferFPAddress - The prefer Futurepass address, used when log in as delegate
+ * @param fpAddressHint - Hinted fpAddress value, used when log in as delegate
  * @returns An `ExtrinsicWrapper` function to be used with the `wrap` function
  */
-export function wrapWithFuturepass(
-	api: ApiPromise,
-	senderAddress: string,
-	preferFPAddress?: string
-) {
+export function wrapWithFuturepass(api: ApiPromise, senderAddress: string, fpAddressHint?: string) {
 	return async (extrinsic: Extrinsic) => {
-		const fetchResult = preferFPAddress
-			? ok(preferFPAddress)
+		const fetchResult = fpAddressHint
+			? ok(fpAddressHint)
 			: await fetchFuturepassAddress(api, senderAddress);
 		if (fetchResult.isErr()) return errPrefix(fetchResult.error.message, fetchResult.error.cause);
 		const fpAddress = fetchResult.value;
@@ -30,9 +26,9 @@ export function wrapWithFuturepass(
 	};
 }
 
-export function futurepassWrapper(preferFPAddress?: string) {
+export function futurepassWrapper(fpAddressHint?: string) {
 	return (api: ApiPromise, senderAddress: string) =>
-		wrapWithFuturepass.bind(undefined, api, senderAddress, preferFPAddress);
+		wrapWithFuturepass.bind(undefined, api, senderAddress, fpAddressHint);
 }
 
 async function fetchFuturepassAddress(api: ApiPromise, senderAddress: string) {

--- a/packages/extrinsic/tests/unit/wrapWithFuturepass.test.ts
+++ b/packages/extrinsic/tests/unit/wrapWithFuturepass.test.ts
@@ -93,4 +93,37 @@ describe("wrapWithFuturepass", () => {
 			`FuturepassWrapper::Unable to extract Futurepass address for "0x0"`
 		);
 	});
+
+	test("wraps extrinsic with `futurepass.proxyExtrinsic` with a preferred fpAddress", async () => {
+		const api = {
+			query: {
+				futurepass: {
+					holders: jest.fn(() => {
+						return Promise.resolve({
+							isEmpty: false,
+							unwrap() {
+								return "0xe";
+							},
+						});
+					}),
+				},
+			},
+
+			tx: {
+				futurepass: {
+					proxyExtrinsic: jest.fn(),
+				},
+			},
+		};
+
+		const senderAddress = "0x0";
+		const fpAddress = "0xf";
+		const extrinsic = {} as Extrinsic;
+		const wrapper = wrapWithFuturepass(api as unknown as ApiPromise, senderAddress, fpAddress);
+		const wrapResult = await wrapper(extrinsic);
+
+		expect(wrapResult.isOk()).toEqual(true);
+		expect(api.tx.futurepass.proxyExtrinsic).toBeCalledTimes(1);
+		expect(api.tx.futurepass.proxyExtrinsic).toHaveBeenCalledWith(fpAddress, extrinsic);
+	});
 });

--- a/packages/extrinsic/tests/unit/wrapWithFuturepass.test.ts
+++ b/packages/extrinsic/tests/unit/wrapWithFuturepass.test.ts
@@ -117,13 +117,13 @@ describe("wrapWithFuturepass", () => {
 		};
 
 		const senderAddress = "0x0";
-		const fpAddress = "0xf";
+		const fpAddressHint = "0xf";
 		const extrinsic = {} as Extrinsic;
-		const wrapper = wrapWithFuturepass(api as unknown as ApiPromise, senderAddress, fpAddress);
+		const wrapper = wrapWithFuturepass(api as unknown as ApiPromise, senderAddress, fpAddressHint);
 		const wrapResult = await wrapper(extrinsic);
 
 		expect(wrapResult.isOk()).toEqual(true);
 		expect(api.tx.futurepass.proxyExtrinsic).toBeCalledTimes(1);
-		expect(api.tx.futurepass.proxyExtrinsic).toHaveBeenCalledWith(fpAddress, extrinsic);
+		expect(api.tx.futurepass.proxyExtrinsic).toHaveBeenCalledWith(fpAddressHint, extrinsic);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
   packages/api-types:
     dependencies:
       '@polkadot/types':
-        specifier: ^10.8.1
+        specifier: 10.9.1
         version: 10.9.1
     devDependencies:
       '@polkadot/api-base':
@@ -127,7 +127,7 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0
       '@polkadot/keyring':
-        specifier: ^12.6.2
+        specifier: 12.6.2
         version: 12.6.2(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)
       '@therootnetwork/api':
         specifier: ^1.0.8
@@ -1652,7 +1652,7 @@ packages:
     resolution: {integrity: sha512-AJEXChcf/nKXd5Q/YLEV5dXQMle3UNT7jcXYmIffZAo/KI394a+/24PaISyQjoNC0fkzS1Q8T5pnGGHmXiVz2g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': '*'
+      '@polkadot/util': 12.6.2
       '@polkadot/x-randomvalues': '*'
     dependencies:
       '@polkadot/util': 12.6.2
@@ -1664,7 +1664,7 @@ packages:
     resolution: {integrity: sha512-QP5eiUqUFur/2UoF2KKKYJcesc71fXhQFLT3D4ZjG28Mfk2ZPI0QNRUfpcxVQmIUpV5USHg4geCBNuCYsMm20Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': '*'
+      '@polkadot/util': 12.6.2
     dependencies:
       '@polkadot/util': 12.6.2
       tslib: 2.6.2
@@ -1673,7 +1673,7 @@ packages:
     resolution: {integrity: sha512-FPq73zGmvZtnuJaFV44brze3Lkrki3b4PebxCy9Fplw8nTmisKo9Xxtfew08r0njyYh+uiJRAxPCXadkC9sc8g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': '*'
+      '@polkadot/util': 12.6.2
       '@polkadot/x-randomvalues': '*'
     dependencies:
       '@polkadot/util': 12.6.2
@@ -1688,7 +1688,7 @@ packages:
     resolution: {integrity: sha512-15wd0EMv9IXs5Abp1ZKpKKAVyZPhATIAHfKsyoWCEFDLSOA0/K0QGOxzrAlsrdUkiKZOq7uzSIgIDgW8okx2Mw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': '*'
+      '@polkadot/util': 12.6.2
     dependencies:
       '@polkadot/util': 12.6.2
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
@@ -1698,7 +1698,7 @@ packages:
     resolution: {integrity: sha512-+neIDLSJ6jjVXsjyZ5oLSv16oIpwp+PxFqTUaZdZDoA2EyFRQB8pP7+qLsMNk+WJuhuJ4qXil/7XiOnZYZ+wxw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': '*'
+      '@polkadot/util': 12.6.2
       '@polkadot/x-randomvalues': '*'
     dependencies:
       '@polkadot/util': 12.6.2
@@ -1714,7 +1714,7 @@ packages:
     resolution: {integrity: sha512-bmD+Dxo1lTZyZNxbyPE380wd82QsX+43mgCm40boyKrRppXEyQmWT98v/Poc7chLuskYb6X8IQ6lvvK2bGR4Tg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': '*'
+      '@polkadot/util': 12.6.2
     dependencies:
       '@polkadot/util': 12.6.2
       tslib: 2.6.2


### PR DESCRIPTION
## Summary

The FuturePass wrapper failed to execute transaction if `senderAddress` is a delegate, not an owner.

This change here allow a FP Address hint from the outside, to overcome the issue.

## Checklist

- [x] Add description
- [x] Tag related issue(s)
- [x] Add appropriate tests
