### PR TITLE
Fix return type for NFT RPC

### DIFF
--- a/packages/api-types/src/interfaces/nft/definitions.ts
+++ b/packages/api-types/src/interfaces/nft/definitions.ts
@@ -34,7 +34,7 @@ export default {
 					type: "u32",
 				},
 			],
-			type: "CollectionDetail",
+			type: "Result<CollectionDetail, Error>",
 		},
 	},
 	types: {

--- a/packages/api/tests/unit/__snapshots__/getApiOptions.test.ts.snap
+++ b/packages/api/tests/unit/__snapshots__/getApiOptions.test.ts.snap
@@ -153,7 +153,7 @@ exports[`getApiOptions returns expected options 1`] = `
             "type": "u32",
           },
         ],
-        "type": "CollectionDetail",
+        "type": "Result<CollectionDetail, Error>",
       },
       "ownedTokens": {
         "description": "Get all NFTs owned by an account",


### PR DESCRIPTION
## Summary

Fix return type for NFT RPC.. Earlier return type did not decode the results well.

<img width="1724" alt="Screenshot 2025-01-17 at 7 48 57 AM" src="https://github.com/user-attachments/assets/f3020571-03a7-4c0e-b086-5c040d3c732d" />

## Checklist

- [x] Add description
- [ ] Tag related issue(s)
- [ ] Add appropriate tests
